### PR TITLE
Remove docker registry dependencies and improvements to allow for building docker images

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "DTLS.Net"]
+	path = DTLS.Net
+	url = https://github.com/CreatorDev/DTLS.Net.git

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -3,7 +3,6 @@
   <packageSources>
     <add key="Microsoft and .NET" value="https://www.nuget.org/api/v2/curated-feeds/microsoftdotnet/" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="nuget-we.flowcloud.systems" value="http://nuget-we.flowcloud.systems/api/odata" />
   </packageSources>
   <disabledPackageSources />
   <activePackageSource>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       context: .
       dockerfile: docker/Dockerfile.base
     command: /bin/true
-    image: 'registry-hh.flowcloud.systems:5000/flowm2m/dotnet-mono-base:latest'
+    image: 'flowm2m/dotnet-mono-base:latest'
     networks:
       - DeviceServerNet
 
@@ -38,7 +38,7 @@ services:
       context: .
       dockerfile: docker/Dockerfile.DeviceServerBuild
     command: /bin/true
-    image: 'registry-hh.flowcloud.systems:5000/flowm2m/deviceserver-build:latest'
+    image: 'flowm2m/deviceserver-build:latest'
     networks:
       - DeviceServerNet
 # ----------------------------------------------------------------------------
@@ -47,7 +47,7 @@ services:
 # Service Discovery and routing
   consul:
     command: agent -dev -bind=172.10.0.10 -client=0.0.0.0
-    image: 'registry-hh.flowcloud.systems:5000/flowops/dockerconsul:latest'
+    image: 'flowops/dockerconsul:latest'
     depends_on:
       # force docker-compose to build base images first
       - dotnet-mono-base
@@ -88,7 +88,7 @@ services:
     environment:
       # Registrator required ENVs
       SERVICE_8443_NAME: "webservice-deviceserver-fabio" # internal load balancer
-    image: registry-hh.flowcloud.systems:5000/flowops/dockerfabio:latest
+    image: 'flowops/dockerfabio:latest'
     networks:
       - DeviceServerNet
     ports:
@@ -161,7 +161,7 @@ services:
       'ServiceConfiguration:ExternalUri': "coaps://${DEVICESERVER_HOSTNAME}:15684"
     env_file:
       - ./appsettings.env
-    image: 'registry-hh.flowcloud.systems:5000/flowm2m/deviceserver-build:latest'
+    image: 'flowm2m/deviceserver-build:latest'
     networks:
       - DeviceServerNet
     tty: true
@@ -186,7 +186,7 @@ services:
       'ServiceConfiguration:ExternalUri': "coaps://${DEVICESERVER_HOSTNAME}:15684"
     env_file:
       - ./appsettings.env
-    image: 'registry-hh.flowcloud.systems:5000/flowm2m/deviceserver-build:latest'
+    image: 'flowm2m/deviceserver-build:latest'
     networks:
       - DeviceServerNet
     tty: true
@@ -217,7 +217,7 @@ services:
     expose:
      - 15683/udp
      - 15684/udp
-    image: 'registry-hh.flowcloud.systems:5000/flowm2m/deviceserver-build:latest'
+    image: 'flowm2m/deviceserver-build:latest'
     networks:
       - DeviceServerNet
     ports:
@@ -255,7 +255,7 @@ services:
      - 5683/udp
      - 5684/udp
      - 14080 
-    image: 'registry-hh.flowcloud.systems:5000/flowm2m/deviceserver-build:latest'
+    image: 'flowm2m/deviceserver-build:latest'
     networks:
       - DeviceServerNet
     ports:
@@ -282,7 +282,7 @@ services:
       - ./appsettings.env
     expose:
      - 14050
-    image: 'registry-hh.flowcloud.systems:5000/flowm2m/deviceserver-build:latest'
+    image: 'flowm2m/deviceserver-build:latest'
     networks:
       - DeviceServerNet
     #restart: always
@@ -314,7 +314,7 @@ services:
       - ./appsettings.env
     expose:
      - 8080
-    image: 'registry-hh.flowcloud.systems:5000/flowm2m/deviceserver-build:latest'
+    image: 'flowm2m/deviceserver-build:latest'
     networks:
       - DeviceServerNet
     #restart: always

--- a/docker/Dockerfile.DeviceServerBuild
+++ b/docker/Dockerfile.DeviceServerBuild
@@ -1,9 +1,13 @@
 
-FROM registry-hh.flowcloud.systems:5000/flowm2m/dotnet-mono-base
+FROM flowm2m/dotnet-mono-base
 
 COPY . /app
 
 WORKDIR /app
+
+RUN mv /app/DTLS.Net/src/DTLS.Net /app/src
+RUN mv /app/DTLS.Net/test/TestClient /app/test
+RUN mv /app/DTLS.Net/test/TestServer /app/test
 
 RUN dotnet restore && \
   dotnet build --configuration=Release src/*

--- a/docker/Dockerfile.DeviceServerTest
+++ b/docker/Dockerfile.DeviceServerTest
@@ -1,8 +1,12 @@
-FROM registry-hh.flowcloud.systems:5000/flowm2m/dotnet-mono-base
+FROM flowm2m/dotnet-mono-base
 
 COPY . /app
 
 WORKDIR /app
+
+RUN mv /app/DTLS.Net/src/DTLS.Net /app/src
+RUN mv /app/DTLS.Net/test/TestClient /app/test
+RUN mv /app/DTLS.Net/test/TestServer /app/test
 
 RUN dotnet restore && \
   dotnet build --configuration=Debug src/* && \


### PR DESCRIPTION
- Remove IMG HH docker registry
- Add DTLS.Net as submodule
- Add DTLS.Net to docker builds

This allows the building most of the docker images required for Device Server, however the flowops Dockerfiles are still required. Documentation needs minor updates for these changes.

I have created the flowm2m organisation on docker hub (https://hub.docker.com/u/flowm2m) to home the mono base image, but this can also be built from scratch as the Dockerfile is included.
