### PR TITLE
Fix creatordev docs URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ A list of ongoing development tasks can be seen [here](doc/tasks.md).
 
 ## Creator IoT framework
 * [The CreatorDev forum](https://forum.creatordev.io/)  
-* [CreatorDev online documentation](https://docs.creatordev.io/wifire)  
+* [CreatorDev online documentation](https://docs.creatordev.io)  
 
 ----
 


### PR DESCRIPTION
Fixed creatordev docs URL at the foot of the readme.md

Signed-off-by: Duncan Frazer <duncan.frazer@imgtec.com>